### PR TITLE
Follow symbolic links and replace them with what they point to

### DIFF
--- a/cmd/portal/send.go
+++ b/cmd/portal/send.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"time"
@@ -91,11 +92,13 @@ func listenForSenderUIUpdates(senderUI *tea.Program, uiCh chan sender.UIUpdate) 
 func prepareFiles(senderClient *sender.Sender, senderUI *tea.Program, fileNames []string, readyCh chan bool, closeFileCh chan *os.File) {
 	files, err := tools.ReadFiles(fileNames)
 	if err != nil {
+		log.Println("Error reading files: ", err)
 		senderUI.Send(ui.ErrorMsg{Message: "Error reading files."})
 		ui.GracefulUIQuit(senderUI)
 	}
 	uncompressedFileSize, err := tools.FilesTotalSize(files)
 	if err != nil {
+		log.Println("Error during file preparation: ", err)
 		senderUI.Send(ui.ErrorMsg{Message: "Error during file preparation."})
 		ui.GracefulUIQuit(senderUI)
 	}
@@ -106,6 +109,7 @@ func prepareFiles(senderClient *sender.Sender, senderUI *tea.Program, fileNames 
 		file.Close()
 	}
 	if err != nil {
+		log.Println("Error compressing files: ", err)
 		senderUI.Send(ui.ErrorMsg{Message: "Error compressing files."})
 		ui.GracefulUIQuit(senderUI)
 	}


### PR DESCRIPTION
This PR fixes and closes #1 by following symbolic links and replacing them with their pointee's contents, entirely removing the symbolic link in the process. The previous behavior was crashing when coming across symbolic links of any sort. 

_There is a different way of doing this_, which is to keep the file structure intact but in the process one will most likely leave the symbolic link dangling. Creating the file that the symbolic link points to is reaching too far in my opinion, as that is most likely not expected by a user receiving a file or folder.

Thus, I landed in this approach, where there aren't any files created outside of the top-most received folder, yet everything concerning the files still should work as expected for the receiver.