### PR TITLE
refactor rendezvous sender client

### DIFF
--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -21,7 +21,7 @@ type SenderOption func(*Sender)
 type Sender struct {
 	payload      io.Reader
 	payloadSize  int64
-	payloadReady chan struct{}
+	payloadReady chan bool
 
 	senderServer *Server
 	closeServer  chan os.Signal
@@ -38,7 +38,7 @@ type Sender struct {
 // New returns a bare bones Sender.
 func New(rendezvousAddress string, rendezvousPort int, opts ...SenderOption) *Sender {
 	closeServerCh := make(chan os.Signal, 1)
-	payloadReady := make(chan struct{})
+	payloadReady := make(chan bool, 1)
 	signal.Notify(closeServerCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	s := &Sender{
@@ -59,7 +59,7 @@ func WithPayload(payload io.Reader, payloadSize int64) SenderOption {
 	return func(s *Sender) {
 		s.payload = payload
 		s.payloadSize = payloadSize
-		close(s.payloadReady) // close to signal that we have a payload to send.
+		s.payloadReady <- true
 	}
 }
 

--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -21,7 +21,7 @@ type SenderOption func(*Sender)
 type Sender struct {
 	payload      io.Reader
 	payloadSize  int64
-	payloadReady chan bool
+	payloadReady chan struct{}
 
 	senderServer *Server
 	closeServer  chan os.Signal
@@ -38,7 +38,7 @@ type Sender struct {
 // New returns a bare bones Sender.
 func New(rendezvousAddress string, rendezvousPort int, opts ...SenderOption) *Sender {
 	closeServerCh := make(chan os.Signal, 1)
-	payloadReady := make(chan bool)
+	payloadReady := make(chan struct{})
 	signal.Notify(closeServerCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	s := &Sender{
@@ -59,7 +59,7 @@ func WithPayload(payload io.Reader, payloadSize int64) SenderOption {
 	return func(s *Sender) {
 		s.payload = payload
 		s.payloadSize = payloadSize
-		s.payloadReady <- true
+		close(s.payloadReady) // close to signal that we have a payload to send.
 	}
 }
 

--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -19,25 +19,31 @@ type SenderOption func(*Sender)
 
 // Sender represents the sender client, handles rendezvous communication and file transfer.
 type Sender struct {
-	payload           io.Reader
-	payloadSize       int64
-	senderServer      *Server
-	closeServer       chan os.Signal
+	payload      io.Reader
+	payloadSize  int64
+	payloadReady chan bool
+
+	senderServer *Server
+	closeServer  chan os.Signal
+
 	receiverIP        net.IP
 	rendezvousAddress string
 	rendezvousPort    int
-	ui                chan<- UIUpdate
 	crypt             *crypt.Crypt
-	state             TransferState
+
+	ui    chan<- UIUpdate
+	state TransferState
 }
 
 // New returns a bare bones Sender.
 func New(rendezvousAddress string, rendezvousPort int, opts ...SenderOption) *Sender {
 	closeServerCh := make(chan os.Signal, 1)
+	payloadReady := make(chan bool)
 	signal.Notify(closeServerCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	s := &Sender{
 		closeServer:       closeServerCh,
+		payloadReady:      payloadReady,
 		rendezvousAddress: rendezvousAddress,
 		rendezvousPort:    rendezvousPort,
 		state:             Initial,
@@ -53,6 +59,7 @@ func WithPayload(payload io.Reader, payloadSize int64) SenderOption {
 	return func(s *Sender) {
 		s.payload = payload
 		s.payloadSize = payloadSize
+		s.payloadReady <- true
 	}
 }
 

--- a/pkg/sender/server_test.go
+++ b/pkg/sender/server_test.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net"
 	"net/http/httptest"
 	"strings"
@@ -22,8 +23,10 @@ func TestTransfer(t *testing.T) {
 	expectedPayload := []byte("A frog walks into a bank...")
 	buf := bytes.NewBuffer(expectedPayload)
 
+	log.Println("1")
 	serverOpts := ServerOptions{receiverIP: net.ParseIP("127.0.0.1"), port: 8080}
 	sender := New("127.0.0.1", 3000, WithServer(serverOpts), WithPayload(buf, int64(buf.Len())))
+	log.Println("2")
 
 	senderPake, _ := pake.InitCurve(weak, 0, "p256")
 	receiverPake, _ := pake.InitCurve(weak, 1, "p256")


### PR DESCRIPTION
- Moved  `ready` channel into the struct and had `WithPayload` signal to it.
- Returned websocket connection instead of sending it over a channel.

These changes do not change any behavior 